### PR TITLE
Set response statusCode during handle_page()

### DIFF
--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -71,6 +71,7 @@ export function get_page_handler(
 		} = get_build_info();
 
 		res.setHeader('Content-Type', 'text/html');
+		res.statusCode = status;
 
 		// preload main js and css
 		// TODO detect other stuff we can preload like fonts?


### PR DESCRIPTION
So can detect in middleware and not run certain logic (again) against error pages. Especially 500 error pages.