### PR TITLE
Create _404.svelte template

### DIFF
--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -76,13 +76,15 @@ export default function start(opts: {
 
 	start_prefetching();
 
-	if (initial_data.error) {
+	const is404 = initial_data.status === 404;
+
+	if (initial_data.error && !is404) {
 		return Promise.resolve().then(() => {
 			return handle_error();
 		});
 	}
 
-	return load_current_page();
+	return load_current_page(is404);
 }
 
 function handle_error() {

--- a/runtime/src/internal/manifest-client.d.ts
+++ b/runtime/src/internal/manifest-client.d.ts
@@ -31,3 +31,4 @@ export const components: DOMComponentLoader[];
 export const ignore: RegExp[];
 export const root_comp: { preload: Preload };
 export const routes: Route[];
+export const not_found: Route;

--- a/runtime/src/internal/manifest-server.d.ts
+++ b/runtime/src/internal/manifest-server.d.ts
@@ -26,6 +26,7 @@ export interface Manifest {
 	ignore: RegExp[];
 	root_comp: SSRComponentModule
 	error: SSRComponent
+	not_found?: ManifestPage
 	pages: ManifestPage[]
 }
 

--- a/runtime/src/server/middleware/get_page_handler.ts
+++ b/runtime/src/server/middleware/get_page_handler.ts
@@ -34,7 +34,7 @@ export function get_page_handler(
 
 	const has_service_worker = fs.existsSync(path.join(build_dir, 'service-worker.js'));
 
-	const { pages, error: error_route } = manifest;
+	const { pages, error: error_route, not_found: not_found_page } = manifest;
 
 	function bail(res: SapperResponse, err: Error | string) {
 		console.error(err);
@@ -46,12 +46,16 @@ export function get_page_handler(
 	}
 
 	function handle_error(req: SapperRequest, res: SapperResponse, statusCode: number, error: Error | string) {
-		handle_page({
-			pattern: null,
-			parts: [
-				{ name: null, component: { default: error_route } }
-			]
-		}, req, res, statusCode, error || 'Unknown error');
+		if (404 === statusCode) {
+			handle_page(not_found_page, req, res, 404, error || 'Page not found');
+		} else {
+			handle_page({
+				pattern: null,
+				parts: [
+					{ name: null, component: { default: error_route } }
+				]
+			}, req, res, statusCode, error || 'Unknown error');
+		}
 	}
 
 	async function handle_page(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,6 +56,7 @@ export type Dirs = {
 export type ManifestData = {
 	root: PageComponent;
 	error: PageComponent;
+	not_found: Page;
 	components: PageComponent[];
 	pages: Page[];
 	server_routes: ServerRoute[];


### PR DESCRIPTION
Work to create a _404.svelte template so my 404 page can operate like any other page and not be baked into client.js file as part of _error.svelte.